### PR TITLE
👷 Simple gitaction for auto PDF creation

### DIFF
--- a/.github/workflows/convert-to-pdf.yml
+++ b/.github/workflows/convert-to-pdf.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           input_dir: wersje tekstowe
           output_dir: pdfs
-          images_dir: dwersje tekstowe/images
+          images_dir: wersje tekstowe/images
           # for example <img src="./images/file-name.png">
           image_import: ./images
           # Default is true, can set to false to only get PDF files

--- a/.github/workflows/convert-to-pdf.yml
+++ b/.github/workflows/convert-to-pdf.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: baileyjm02/markdown-to-pdf@v1.2.0
         with:
           input_dir: wersje tekstowe
-          output_dir: pdfs
+          output_dir: wersje pdf
           images_dir: wersje tekstowe/images
           # for example <img src="./images/file-name.png">
           image_import: ./images

--- a/.github/workflows/convert-to-pdf.yml
+++ b/.github/workflows/convert-to-pdf.yml
@@ -1,0 +1,32 @@
+name: Wersje tekstowe to PDF
+# This workflow is triggered on pushes to the repository.
+on:
+  push:
+    branches:
+      - main
+    # Paths can be used to only trigger actions when you have edited certain files, such as a file within the /docs directory
+    paths:
+      - 'wersje tekstowe/**.md'
+      - 'wersje tekstowe/images/**'
+
+jobs:
+  converttopdf:
+    name: Build PDF
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: baileyjm02/markdown-to-pdf@v1.2.0
+        with:
+          input_dir: wersje tekstowe
+          output_dir: pdfs
+          images_dir: dwersje tekstowe/images
+          # for example <img src="./images/file-name.png">
+          image_import: ./images
+          # Default is true, can set to false to only get PDF files
+          build_html: false
+          build_pdf: true
+      - uses: actions/upload-artifact@v3.1.2
+        with:
+          name: Ustawy o PIT
+          path: pdfs
+

--- a/.github/workflows/convert-to-pdf.yml
+++ b/.github/workflows/convert-to-pdf.yml
@@ -28,5 +28,4 @@ jobs:
       - uses: actions/upload-artifact@v3.1.2
         with:
           name: Ustawy o PIT
-          path: pdfs
-
+          path: wersje pdf

--- a/.github/workflows/convert-to-pdf.yml
+++ b/.github/workflows/convert-to-pdf.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build PDF
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: baileyjm02/markdown-to-pdf@v1.2.0
         with:
           input_dir: wersje tekstowe


### PR DESCRIPTION
Simple pdf auto creation from MD files (as artifact in ACTION)

Next step:

1. Implement release strategy- pdf will be created only for releases.
2. Switch to 'pandoc' or other action for MD to PDF conversion.