### PR TITLE
Kwota ulgi dla seniorów i młodych, ulga na dziecko

### DIFF
--- a/wersje tekstowe/PIT dla zatrudnionych - ustawa.md
+++ b/wersje tekstowe/PIT dla zatrudnionych - ustawa.md
@@ -118,7 +118,7 @@ Przepisów art. 11 nie stosuje się do odpłatnego zbycia:
 
 ### Art. 16. [ulga dla młodych]
 
-1. Zwalnia się przychody podlegające pod opodatkowanie na gruncie niniejszej ustawy, z wyłączeniem Rozdziału 4, otrzymane przez podatnika do ukończenia 26. roku życia, do wysokości nieprzekraczającej w roku podatkowym kwoty 85 528 zł.
+1. Zwalnia się przychody podlegające pod opodatkowanie na gruncie niniejszej ustawy, z wyłączeniem Rozdziału 4, otrzymane przez podatnika do ukończenia 26. roku życia, do wysokości nieprzekraczającej w roku podatkowym kwoty dwudziestocztero krotności minimalnego wynagrodzenia za pracę o którym mowa w rozporządzeniu wydanym na podstawie art. 2 ust. 5 ustawy z dnia 10 października 2002 r. o minimalnym wynagrodzeniu za pracę.
 2. Nadwyżka ponad tę kwotę otrzymana przez podatnika, o którym mowa w ust. 1, opodatkowana jest zgodnie z przepisami Rozdziału 3.
 
 ### Art. 17. [ulga na dzieci]
@@ -127,7 +127,7 @@ Przepisów art. 11 nie stosuje się do odpłatnego zbycia:
    1. wykonywał władzę rodzicielską;
    2. pełnił funkcję opiekuna prawnego, jeżeli dziecko z nim zamieszkiwało;
    3. sprawował opiekę poprzez pełnienie funkcji rodziny zastępczej na podstawie orzeczenia sądu lub umowy zawartej ze starostą.
-2. Odliczeniu podlega kwota 500 zł za każdy miesiąc kalendarzowy roku podatkowego, w którym podatnik wykonywał władzę, pełnił funkcję albo sprawował opiekę, o których mowa w ust. 1, w stosunku do:
+2. Odliczeniu podlega kwota 1000 zł za każdy miesiąc kalendarzowy roku podatkowego, w którym podatnik wykonywał władzę, pełnił funkcję albo sprawował opiekę, o których mowa w ust. 1, w stosunku do:
    1. małoletniego dziecka;
    2. pełnoletniego dziecka, które zgodnie z odrębnymi przepisami otrzymywały zasiłek (dodatek) pielęgnacyjny lub rentę socjalną.
 3. W przypadku gdy w tym samym miesiącu kalendarzowym w stosunku do dziecka wykonywana jest władza, pełniona funkcja lub sprawowana opieka, o których mowa w ust. 1, każdemu z podatników przysługuje odliczenie w kwocie stanowiącej 1/30 kwoty obliczonej zgodnie z ust. 2 za każdy dzień sprawowania pieczy nad dzieckiem.
@@ -146,7 +146,7 @@ Przepisów art. 11 nie stosuje się do odpłatnego zbycia:
 
 ### Art. 19. [ulga dla emerytów]
 
-1. Zwalnia się przychody podlegające pod opodatkowanie na gruncie niniejszej ustawy, z wyłączeniem Rozdziału 4, otrzymane przez podatnika po ukończeniu wieku emerytalnego, do wysokości nieprzekraczającej w roku podatkowym kwoty 85 528 zł, pod warunkiem niepobierania przez tegoż podatnika świadczenia emerytalnego.
+1. Zwalnia się przychody podlegające pod opodatkowanie na gruncie niniejszej ustawy, z wyłączeniem Rozdziału 4, otrzymane przez podatnika po ukończeniu wieku emerytalnego, do wysokości nieprzekraczającej w roku podatkowym kwoty dwudziestocztero krotności minimalnego wynagrodzenia za pracę o którym mowa w rozporządzeniu wydanym na podstawie art. 2 ust. 5 ustawy z dnia 10 października 2002 r. o minimalnym wynagrodzeniu za pracę, pod warunkiem niepobierania przez tegoż podatnika świadczenia emerytalnego.
 2. Nadwyżka ponad tę kwotę otrzymana przez podatnika, o którym mowa w ust. 1, opodatkowana jest zgodnie z przepisami Rozdziału 3.
 
 ### Art. 20. [ulga kredytowa]


### PR DESCRIPTION
Podniesienie kwoty ulgi na dziecko do 1000 złotych odliczenia.  Uzależnienie kwoty ulgi dla seniorów i młodych od minimalnego wynagrodzenia na poziomie 24-krotności.